### PR TITLE
Added error handler details.

### DIFF
--- a/lib/get-certificate.js
+++ b/lib/get-certificate.js
@@ -200,7 +200,7 @@ module.exports.create = function (deps) {
     }
 
     function ensureValidation(err, res, body, unlink) {
-      var authz;
+      var authz, challengesState;
 
       if (err || Math.floor(res.statusCode/100)!==2) {
         unlink();
@@ -235,7 +235,17 @@ module.exports.create = function (deps) {
         nextDomain();
       } else if (authz.status==='invalid') {
         unlink();
-        return handleErr(null, 'The CA was unable to validate the file you provisioned: ' + authz.detail, body);
+        challengesState = state.challenges.map(function (challenge) {
+          var result =  ' - ' + challenge.uri + ' [' + challenge.status + ']';
+          if (result.error) {
+            result += '\n   ' + result.error.detail;
+          }
+          return result;
+        }).join('\n');
+        return handleErr(null,
+            'The CA was unable to validate the file you provisioned. '
+          + (authz.detail ? 'Details: ' + authz.detail : '')
+          + (challengesState ? '\n' + challengesState : ''), body);
       } else {
         unlink();
         return handleErr(null, 'CA returned an authorization in an unexpected state' + authz.detail, authz);


### PR DESCRIPTION
When the challenges failed then the letsencrypt api doesn't show an error message. This results in a hardly understandable error message: 

```
CA returned an authorization in an unexpected state: undefined
```

However the data returned from the server would be much more conclusive:

```JSON
{
  "identifier": {
    "type": "dns",
    "value": "team.nodeschool.io"
  },
  "status": "invalid",
  "expires": "2016-02-22T11:14:56Z",
  "challenges": [{
      "type": "dns-01",
      "status": "pending",
      "uri": "https://acme-v01.api.letsencrypt.org/acme/challenge/CIt2SMZdUFK3w1h6zusgAjZWu13rj9vRnCU1XcEFFMA/17016733",
      "token": "KgDijEpkO-bKxzcGkgpWmGnsf49UnLeH0JDi9r9eonQ"
    }, {
      "type": "tls-sni-01",
      "status": "pending",
      "uri": "https://acme-v01.api.letsencrypt.org/acme/challenge/CIt2SMZdUFK3w1h6zusgAjZWu13rj9vRnCU1XcEFFMA/17016734",
      "token": "KC_gJ8BMnSHYo6RkOnk0uhzfOZf2RgdhcBsjh8Zeov0"
    }, {
      "type": "http-01",
      "status": "invalid",
      "error": {
        "type": "urn:acme:error:connection",
        "detail": "Could not connect to http://team.nodeschool.io/.well-known/acme-challenge/hpShW5jwxlmBc_z_Tzf8RWF9FkUjcgKwEEFhlymdlzc"
      },
      "uri": "https://acme-v01.api.letsencrypt.org/acme/challenge/CIt2SMZdUFK3w1h6zusgAjZWu13rj9vRnCU1XcEFFMA/17016735",
      "token": "hpShW5jwxlmBc_z_Tzf8RWF9FkUjcgKwEEFhlymdlzc",
      "keyAuthorization": "hpShW5jwxlmBc_z_Tzf8RWF9FkUjcgKwEEFhlymdlzc.o63o6whKEdKPJb8VHy5VHNddDxagQbBqbagPh8vQunc",
      "validationRecord": [{
          "url": "http://team.nodeschool.io/.well-known/acme-challenge/hpShW5jwxlmBc_z_Tzf8RWF9FkUjcgKwEEFhlymdlzc",
          "hostname": "team.nodeschool.io",
          "port": "80",
          "addressesResolved": ["81.95.5.101"],
          "addressUsed": "81.95.5.101"
        }]}
  ],
  "combinations": [[0],[1],[2]]
}
```

This PR should add a better, more-detailed message.